### PR TITLE
Add SELinux local policy module

### DIFF
--- a/selinux/collectd-haproxy.te
+++ b/selinux/collectd-haproxy.te
@@ -1,0 +1,14 @@
+module collectd-haproxy 1.0;
+
+require {
+	type collectd_t;
+	type haproxy_t;
+	type haproxy_var_lib_t;
+	class sock_file write;
+	class unix_stream_socket connectto;
+}
+
+#============= collectd_t ==============
+
+allow collectd_t haproxy_t:unix_stream_socket connectto;
+allow collectd_t haproxy_var_lib_t:sock_file write;


### PR DESCRIPTION
This policy allows children of the collectd process to operate with Haproxy's stats socket. This should work on all RedHat-based systems.

```
# ps axZ | grep collectd_t
system_u:system_r:collectd_t:s0  5144 ?        Ssl    2:08 /usr/sbin/collectd
# ls -Z /var/lib/haproxy/stats
srwxr-xr-x. root root system_u:object_r:haproxy_var_lib_t:s0 /var/lib/haproxy/stats
```

Without this policy the plugin won't work on systems that are enforcing SELinux.

The idea is to compile and install it via the software distribution system of choice (for instance, RPM). I'm happy to provide a spec file, just let me know.

