### PR TITLE
Allow multiple values under ExcludeMetric

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -299,7 +299,7 @@ def config(config_values):
         elif node.key == "EnhancedMetrics" and node.values[0]:
             enhanced_metrics = _str_to_bool(node.values[0])
         elif node.key == "ExcludeMetric" and node.values[0]:
-            excluded_metrics.add(node.values[0])
+            excluded_metrics.extend(node.values)
         elif node.key == "Testing" and node.values[0]:
             testing = _str_to_bool(node.values[0])
         elif node.key == 'Dimension':


### PR DESCRIPTION
This commit allows to define ExcludeMetric configuration with either

ExcludeMetric xxx
ExcludeMetric yyy

or

ExcludeMetric xxx yyy

Main use case for this, is to configure haproxy plugin via Puppet,
which only accepts the second way of configuring the python plugins