### PR TITLE
Add possibility to format  plugin_instance

### DIFF
--- a/test_haproxy.py
+++ b/test_haproxy.py
@@ -144,3 +144,13 @@ mock_config_enhanced_sample.children = [
 @patch('haproxy.HAProxySocket', MockHAProxySocket)
 def test_enhanced_metrics():
     haproxy.collect_metrics(haproxy.config(mock_config_enhanced_sample))
+	
+mock_config_plugin_type_instance = Mock()
+mock_config_plugin_type_instance.children = [
+    ConfigOption('PluginInstanceFormat', ('{proxy_name}_{service_name}"',)),
+    ConfigOption('Testing', ('True',))
+]
+
+@patch('haproxy.HAProxySocket', MockHAProxySocket)
+def test_plugininstance_testinstance_format():
+    haproxy.collect_metrics(haproxy.config(mock_config_plugin_type_instance))


### PR DESCRIPTION
This is a backwards compatible patch, and allows to define your own format for plugin_instance values sent to collectd.

When backend and frontend are configured, the plugin creates several entries and plugin instance gets appended a list of key-value pairs that collectd truncates like this:

```
cci-lb-keystone-q79242.cern.ch/haproxy-[proxy_name=cloud_identity_backend_main,service_name=BACKEND,pr/gauge-session_rate
cci-lb-keystone-q79242.cern.ch/haproxy-[proxy_name=cloud_identity_backend_main,service_name=BACKEND,pr/gauge-session_rate_max
cci-lb-keystone-q79242.cern.ch/haproxy-[proxy_name=cloud_identity_backend_main,service_name=BACKEND,pr/gauge-session_time_avg
cci-lb-keystone-q79242.cern.ch/haproxy-[proxy_name=cloud_identity_backend_main,service_name=FRONTEND,p/counter-conn_total
cci-lb-keystone-q79242.cern.ch/haproxy-[proxy_name=cloud_identity_backend_main,service_name=FRONTEND,p/derive-bytes_in
cci-lb-keystone-q79242.cern.ch/haproxy-[proxy_name=cloud_identity_backend_main,service_name=FRONTEND,p/derive-bytes_out
```

At the moment plugin_instance is a csv list enclosed with [] with all details of each entry while type_instance is just the metric. If we would like to set plugin_instance to {proxy_name}_{service_name}, we only need to set the PluginInstanceFormat in collectd for this plugin
```
PluginInstanceFormat '{proxy_name}_{service_name}'
ProxyMonitor "server" "frontend" "backend"
EnhancedMetrics true
```

When this configuration is set, the previous values are shown like this in collectd

```
cci-lb-keystone-q79242.cern.ch/haproxy-cloud_identity_backend_main-backend/gauge-session_rate
cci-lb-keystone-q79242.cern.ch/haproxy-cloud_identity_backend_main-backend/gauge-session_rate_max
cci-lb-keystone-q79242.cern.ch/haproxy-cloud_identity_backend_main-backend/gauge-session_time_avg
cci-lb-keystone-q79242.cern.ch/haproxy-cloud_identity_backend_main-frontend/counter-conn_total
cci-lb-keystone-q79242.cern.ch/haproxy-cloud_identity_backend_main-frontend/derive-bytes_in
cci-lb-keystone-q79242.cern.ch/haproxy-cloud_identity_backend_main-frontend/derive-bytes_out
```

To keep backwards compatibility, if the format is not specified, the previous behavior is kept.